### PR TITLE
More Realistic Player Jumping Logic

### DIFF
--- a/Assets/Scripts/MovePB.cs
+++ b/Assets/Scripts/MovePB.cs
@@ -10,18 +10,18 @@ public class MovePB : MonoBehaviour
     private bool _userJumped;
 
     private const float _inputScale = 0.5f;
-
+    private const float _groundThreshold = 0.1f;
+    private const float _jumpMultiplier = 1.6f;
+    
     private Rigidbody _rigidbody;
     private Transform _transform;
 
-    // Start is called before the first frame update
     void Start()
     {
         _rigidbody = GetComponent<Rigidbody>();
         _transform = GetComponent<Transform>();
     }
 
-    // Update is called once per frame
     void Update()
     {
         _playerInput = Input.GetAxis("Vertical");
@@ -36,10 +36,12 @@ public class MovePB : MonoBehaviour
 
         _transform.rotation = Quaternion.Euler(_userRot);
         _rigidbody.velocity += transform.forward * _playerInput * _inputScale;
-
-        if(_userJumped)
+        
+        // If the player is *close* to the ground, the jump will be triggered.
+        // This allows for a "harder"/"longer" keypress to enable a slightly larger jump.
+        if(_userJumped && _transform.position[1] <= _groundThreshold)
         {
-            _rigidbody.AddForce(Vector3.up, ForceMode.VelocityChange);
+            _rigidbody.AddForce(Vector3.up * _jumpMultiplier, ForceMode.Impulse);
             _userJumped = false;
         }
     }


### PR DESCRIPTION
- make jumps only occur from ground or close to the ground
- If the player is *close* to the ground, the jump will be triggeredd. 
This allows for a "harder"/"longer" keypress to enable a slightly larger jump.

